### PR TITLE
First section styling with the before created components.

### DIFF
--- a/src/lib/BackHomeBtn.svelte
+++ b/src/lib/BackHomeBtn.svelte
@@ -18,8 +18,8 @@
         align-items: center;
         color: inherit;
         text-decoration: none;
-        font-size: 12px;
-        gap: 8px;
+        font-size: .75em;
+        gap: .5em;
     }
 
 </style>

--- a/src/lib/BackHomeBtn.svelte
+++ b/src/lib/BackHomeBtn.svelte
@@ -1,16 +1,25 @@
-<style>
-    a {
-        color: inherit;
-        text-decoration: none;
-    }
-</style>
+<script>
+
+</script>
 
 <a href="/">
     <svg fill="#000000"
-	 width="16px" height="16px" viewBox="0 0 52 52" enable-background="new 0 0 52 52" xml:space="preserve">
+	 width="14px" height="14px" viewBox="0 0 52 52" enable-background="new 0 0 52 52" xml:space="preserve">
     <path d="M48.6,23H15.4c-0.9,0-1.3-1.1-0.7-1.7l9.6-9.6c0.6-0.6,0.6-1.5,0-2.1l-2.2-2.2c-0.6-0.6-1.5-0.6-2.1,0
 	L2.5,25c-0.6,0.6-0.6,1.5,0,2.1L20,44.6c0.6,0.6,1.5,0.6,2.1,0l2.1-2.1c0.6-0.6,0.6-1.5,0-2.1l-9.6-9.6C14,30.1,14.4,29,15.3,29
 	h33.2c0.8,0,1.5-0.6,1.5-1.4v-3C50,23.8,49.4,23,48.6,23z"/>
     </svg>
     TERUG NAAR HOME
 </a>
+
+<style>
+    a {
+        display: flex;
+        align-items: center;
+        color: inherit;
+        text-decoration: none;
+        font-size: 12px;
+        gap: 8px;
+    }
+
+</style>

--- a/src/lib/descriptionText.svelte
+++ b/src/lib/descriptionText.svelte
@@ -7,5 +7,7 @@
 </p>
 
 <style>
-    
+    p {
+        text-align: center;
+    }
 </style>

--- a/src/routes/vacatures/+page.svelte
+++ b/src/routes/vacatures/+page.svelte
@@ -13,14 +13,42 @@
 
     <section class="landing-section">
         <BackHomeBtn/>
-
         <MainTitle
         label="VACATURES"
         />
-        
         <DescriptionText
         label="Verslim je carrière bij de beste digitale bureaus van Nederland. Pak je rol als developer of designer, researcher, als scrum master of marketeer, als strateeg. Start of groei door – en laat zien wat je kan."
         />
     </section>
 
 </main>
+
+
+<style>
+    main {
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+    }
+
+    .landing-section {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+        max-width: 80%;
+        text-align: center;
+        gap: 1.25em;
+        margin-top: 7.5em;
+    }
+
+    @media (min-width: 820px){
+        .landing-section {
+            margin-top: 12.5%;
+            max-width: 50%;
+        }
+    }
+
+
+</style>


### PR DESCRIPTION
## What does this change ❔ 

Resolves issue #21

Met deze PR wil ik de styling voor de eerste section pushen waarbij ik de voorheen gecreërde components in een responsive layout zet. De styling voor de layout staat in de +page.svelte van de svelte route.

Verder voldoet de PR zich aan de afspraken, best practices en code conventions die we hebben afgesproken waaronder de kebab-case convention en het gelijk testen van code. #3 

## How Has This Been Tested? 🧪 

De styling is gelijk getest in de browser tijdens het bouwen en ook gecheckt met PolyPane. 

## Images

<img width="1624" alt="Screenshot 2024-09-26 at 23 10 29" src="https://github.com/user-attachments/assets/47f8bb2f-3ba3-4332-912b-79be87024aef">

Referentie van design 

![image](https://github.com/user-attachments/assets/2a0644e3-44e3-40c9-a450-73f3eab21969)


## How to review

Voor het reviewen van deze PR kun je letten of de HTML & CSS semantisch is geschreven en verifieren of het zich inderdaad voldoet aan de afspraken, best practices en code conventions die zijn afgesproken. 
