### PR TITLE
Vacature component

### DIFF
--- a/src/lib/Vacancy.svelte
+++ b/src/lib/Vacancy.svelte
@@ -5,19 +5,41 @@
 </script>
 
 <article>
-    <slot name="job-title" class=""/>
-    <slot name="language" class=""/>
-    <slot name="company" class=""/>
-    <slot name="city" class=""/>
-    <slot name="link" class=""/>
+    <slot name="job-title"/>
+    <slot name="language"/>
+    <slot name="company"/>
+    <slot name="workweek-indication"/>
+    <slot name="city" class="city"/>
+    <slot name="link" class="link"/>
 </article>
 
 <style>
 
 article {
-    display: flex;
-    flex-wrap: wrap;
-    margin: 1em;
+    display: grid;
+    grid-template-columns: 1fr 1fr; /* Two equal columns */
+    grid-template-rows: auto auto auto auto; /* Three rows */
+    gap: 2em 0; /* Adds spacing between the elements */
+    align-items: center;
+    margin-bottom: 15%;
 }
+
+@media (min-width: 620px){
+    article {
+        grid-template-columns: repeat(3, 1fr);
+        margin-bottom: 5%;
+        
+    }
+
+}
+
+@media (min-width: 820px){
+    article {
+        display: flex;
+        flex-direction: row;
+        justify-content: space-between;
+    }
+}
+
 
 </style>

--- a/src/lib/Vacancy.svelte
+++ b/src/lib/Vacancy.svelte
@@ -21,6 +21,10 @@ article {
     border-bottom: 1px solid black;
 }
 
+article:last-child {
+    border-bottom: none;
+}
+
 @media (min-width: 620px){
     article {
         grid-template-columns: repeat(3, 1fr);

--- a/src/lib/Vacancy.svelte
+++ b/src/lib/Vacancy.svelte
@@ -16,7 +16,7 @@ article {
     grid-template-rows: auto auto auto auto;
     gap: 2em 0;
     align-items: center;
-    margin-bottom: 15%;
+    margin-bottom: 20%;
 }
 
 @media (min-width: 620px){

--- a/src/lib/Vacancy.svelte
+++ b/src/lib/Vacancy.svelte
@@ -16,13 +16,16 @@ article {
     grid-template-rows: auto auto auto auto;
     gap: 2em 0;
     align-items: center;
-    margin-bottom: 20%;
+    margin-bottom: 15%;
+    padding-bottom: 15%;
+    border-bottom: 1px solid black;
 }
 
 @media (min-width: 620px){
     article {
         grid-template-columns: repeat(3, 1fr);
-        margin-bottom: 5%;
+        margin-bottom: 10%;
+        padding-bottom: 10%;
         
     }
 
@@ -33,6 +36,8 @@ article {
         display: flex;
         flex-direction: row;
         justify-content: space-between;
+        margin-bottom: 5%;
+        padding-bottom: 5%;
     }
 }
 

--- a/src/lib/Vacancy.svelte
+++ b/src/lib/Vacancy.svelte
@@ -1,8 +1,3 @@
-<script>
-    
-    import Link from "$lib/Link.svelte";
-
-</script>
 
 <article>
     <slot name="job-title"/>

--- a/src/lib/Vacancy.svelte
+++ b/src/lib/Vacancy.svelte
@@ -1,0 +1,23 @@
+<script>
+    
+    import Link from "$lib/Link.svelte";
+
+</script>
+
+<article>
+    <slot name="job-title" class=""/>
+    <slot name="language" class=""/>
+    <slot name="company" class=""/>
+    <slot name="city" class=""/>
+    <slot name="link" class=""/>
+</article>
+
+<style>
+
+article {
+    display: flex;
+    flex-wrap: wrap;
+    margin: 1em;
+}
+
+</style>

--- a/src/lib/Vacancy.svelte
+++ b/src/lib/Vacancy.svelte
@@ -17,9 +17,9 @@
 
 article {
     display: grid;
-    grid-template-columns: 1fr 1fr; /* Two equal columns */
-    grid-template-rows: auto auto auto auto; /* Three rows */
-    gap: 2em 0; /* Adds spacing between the elements */
+    grid-template-columns: 1fr 1fr; 
+    grid-template-rows: auto auto auto auto;
+    gap: 2em 0;
     align-items: center;
     margin-bottom: 15%;
 }

--- a/src/routes/vacatures/+page.svelte
+++ b/src/routes/vacatures/+page.svelte
@@ -2,13 +2,14 @@
   import Header from "../../lib/Header.svelte";
     import Text from "$lib/Text.svelte";
     import Link from "$lib/Link.svelte";
+    import Vacancy from "$lib/Vacancy.svelte";
 </script>
 
   <Header />
 
 <main>
     <section class="intro-section">
-        
+    
         <Link href="/" clazz="back-to-home">
             <svg slot="svg-icon-left"
                  width="16" height="16" viewBox="0 0 24 24" fill="none">
@@ -24,6 +25,27 @@
             </p>
         </Text>
     
+    </section>
+
+    <section class="vacancies-section">
+        <Vacancy>
+            <h4 slot="job-title">Design Lead</h4>
+            <span slot="language">ENG & NL</span>
+            <span slot="company">TRIPLE</span>
+            <span slot="city">AMSTERDAM</span>
+
+            <Link 
+                slot="link" 
+                href="/"
+                clazz="detail-link"
+            >
+                <span slot="link-text">BEKIJKEN</span>
+                <svg slot="svg-icon-right"
+                width="16" height="16" viewBox="0 0 24 24" fill="none">
+                <path d="M7 17L17 7M17 7H8M17 7V16" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+            </Link>
+        </Vacancy>
     </section>
 </main>
 

--- a/src/routes/vacatures/+page.svelte
+++ b/src/routes/vacatures/+page.svelte
@@ -29,10 +29,49 @@
 
     <section class="vacancies-section">
         <Vacancy>
-            <h4 slot="job-title">Design Lead</h4>
-            <span slot="language">ENG & NL</span>
-            <span slot="company">TRIPLE</span>
-            <span slot="city">AMSTERDAM</span>
+            <h4 slot="job-title" class="job-title">Design Lead</h4>
+            <span slot="language" class="language">LANUAGE</span>
+            <span slot="company" class="company">COMPANY</span>
+            <span slot="workweek-indication" class="workweek">32-40</span>
+            <span slot="city" class="city" >AMSTERDAM</span>
+
+            <Link 
+                slot="link" 
+                href="/"
+                clazz="detail-link"
+            >
+                <span slot="link-text">BEKIJKEN</span>
+                <svg slot="svg-icon-right"
+                width="16" height="16" viewBox="0 0 24 24" fill="none">
+                <path d="M7 17L17 7M17 7H8M17 7V16" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+            </Link>
+        </Vacancy>
+        <Vacancy>
+            <h4 slot="job-title" class="job-title">React Front-End Developer</h4>
+            <span slot="language" class="language">LANUAGE</span>
+            <span slot="company" class="company">COMPANY</span>
+            <span slot="workweek-indication" class="workweek">32-40</span>
+            <span slot="city" class="city" >AMSTERDAM</span>
+
+            <Link 
+                slot="link" 
+                href="/"
+                clazz="detail-link"
+            >
+                <span slot="link-text">BEKIJKEN</span>
+                <svg slot="svg-icon-right"
+                width="16" height="16" viewBox="0 0 24 24" fill="none">
+                <path d="M7 17L17 7M17 7H8M17 7V16" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+            </Link>
+        </Vacancy>
+        <Vacancy>
+            <h4 slot="job-title" class="job-title">Design Lead maar ook dit en dat en nog wat meer</h4>
+            <span slot="language" class="language">LANUAGE</span>
+            <span slot="company" class="company">COMPANY</span>
+            <span slot="workweek-indication" class="workweek">32-40</span>
+            <span slot="city" class="city" >AMSTERDAM</span>
 
             <Link 
                 slot="link" 
@@ -49,7 +88,6 @@
     </section>
 </main>
 
-
 <style>
 
     .intro-section {
@@ -62,9 +100,75 @@
         margin: 25% 15% 10% 15%;
     }
 
+    /* #region Vacatures */
+    .vacancies-section {
+        display: flex;
+        flex-direction: column;
+        margin: 0 10% 0 10%;
+    }
+
+    .job-title {
+        grid-column: 1 / span 2; 
+        grid-row: 1;
+    }
+
+    .language {
+        grid-column: 1;
+        grid-row: 2; 
+    }
+
+    .company {
+        grid-column: 2;
+        grid-row: 2;
+    }
+
+    .workweek {
+        grid-column: 1;
+        grid-row: 3; 
+    }
+
+    .city {
+        grid-column: 2;
+        grid-row: 3;
+    }
+
+    /* #endregion */
+
+    @media (min-width: 620px){
+        .job-title {
+            grid-column: 1 / span 3; 
+            grid-row: 1;
+        }
+
+        .language {
+            grid-column: 1;
+            grid-row: 2; 
+        }
+
+        .company {
+            grid-column: 2;
+            grid-row: 2;
+        }
+
+        .workweek {
+            grid-column: 3;
+            grid-row: 2; 
+        }
+
+        .city {
+            grid-column: 1;
+            grid-row: 3;
+        }
+    }
+
+
     @media (min-width: 820px){
         .intro-section {
             margin-top: 12.5%;
+        }
+
+        .job-title {
+            width: 20%;
         }
     }
 

--- a/src/routes/vacatures/+page.svelte
+++ b/src/routes/vacatures/+page.svelte
@@ -123,7 +123,7 @@
     .vacancies-section {
         display: flex;
         flex-direction: column;
-        margin: 0 10% 0 10%;
+        margin: 0 12.5% 0 12.5%;
     }
 
     .job-title {
@@ -195,6 +195,10 @@
         .intro-section {
             margin: 12.5% 25% 10% 25%;
         }
+
+        .vacancies-section {
+        margin: 0 5% 0 5%;
+    }
     }
 
     @media (min-width: 1524px){

--- a/src/routes/vacatures/+page.svelte
+++ b/src/routes/vacatures/+page.svelte
@@ -126,6 +126,10 @@
         margin: 0 7.5% 0 7.5%;
     }
 
+    .language, .company, .workweek, .city {
+        font-family: var(--martian-mono);
+    }
+
     .job-title {
         grid-column: 1 / span 2; 
         grid-row: 1;

--- a/src/routes/vacatures/+page.svelte
+++ b/src/routes/vacatures/+page.svelte
@@ -168,7 +168,7 @@
         }
 
         .job-title {
-            width: 20%;
+            width: 20%; /* Zorgt ervoor dat dit vakje niet breder word en de rest beinvloed */ 
         }
     }
 

--- a/src/routes/vacatures/+page.svelte
+++ b/src/routes/vacatures/+page.svelte
@@ -85,6 +85,25 @@
             </svg>
             </Link>
         </Vacancy>
+        <Vacancy>
+            <h4 slot="job-title" class="job-title">Traffic Manager</h4>
+            <span slot="language" class="language">LANUAGE</span>
+            <span slot="company" class="company">COMPANY</span>
+            <span slot="workweek-indication" class="workweek">32-40</span>
+            <span slot="city" class="city" >AMSTERDAM</span>
+
+            <Link 
+                slot="link" 
+                href="/"
+                clazz="detail-link"
+            >
+                <span slot="link-text">BEKIJKEN</span>
+                <svg slot="svg-icon-right"
+                width="16" height="16" viewBox="0 0 24 24" fill="none">
+                <path d="M7 17L17 7M17 7H8M17 7V16" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+            </Link>
+        </Vacancy>
     </section>
 </main>
 

--- a/src/routes/vacatures/+page.svelte
+++ b/src/routes/vacatures/+page.svelte
@@ -123,7 +123,7 @@
     .vacancies-section {
         display: flex;
         flex-direction: column;
-        margin: 0 12.5% 0 12.5%;
+        margin: 0 7.5% 0 7.5%;
     }
 
     .job-title {


### PR DESCRIPTION
## What does this change ❓ 

Resolves issue #41

Met deze pull request wil ik het vacature component pushen die ook makkelijk aanpasbaar is maar alleen voor de vacature pagina, later zouden we nog kunnen kijken naar een globaal artikel element die voor alle pagina's inzetbaar is. Ik heb de zelfde techniek gebruikt als het Link component : named slots waardoor we makkelijk verschillende elementen kunnen doorgeven. 

Als we data uit de API hebben kunnen we dit component in een for each zetten. 

## How Has This Been Tested 🧪 

De responsiveness heb ik getest met Polypane. Bekijk de demo hieronder

https://github.com/user-attachments/assets/75b31398-1683-44fb-a659-6fdb7b353148

## How to review

Nachecken of de code voldoet aan de afgesproken best practices en conventies. 