### PR TITLE
Vacature layout remake

### DIFF
--- a/src/lib/IntroSection.svelte
+++ b/src/lib/IntroSection.svelte
@@ -40,18 +40,18 @@
     justify-content: center;
     text-align: center;
     gap: 0.75em;
-    margin: 7.5% 0 10% 0;
+    margin: 7.5% 0 15% 0;
   }
 
   @media (min-width: 842px ){
       .intro-section {
-        margin: 7.5% 20% 15% 20%;
+        margin: 7.5% 20% 5% 20%;
       }
   }
 
   @media (min-width: 1332px ){
       .intro-section {
-        margin: 7.5% 25% 15% 25%;
+        margin: 7.5% 25% 5% 25%;
       }
   }
 </style>

--- a/src/lib/IntroSection.svelte
+++ b/src/lib/IntroSection.svelte
@@ -32,8 +32,6 @@
   <p><slot name="subtitle">{subtitle}</slot></p>
 </section>
 
-<!--More text elements if needed-->
-
 <style>
   .intro-section {
     display: flex;
@@ -42,6 +40,18 @@
     justify-content: center;
     text-align: center;
     gap: 0.75em;
-    margin: 10% 15% 10% 15%;
+    margin: 7.5% 0 10% 0;
+  }
+
+  @media (min-width: 842px ){
+      .intro-section {
+        margin: 7.5% 20% 15% 20%;
+      }
+  }
+
+  @media (min-width: 1332px ){
+      .intro-section {
+        margin: 7.5% 25% 15% 25%;
+      }
   }
 </style>

--- a/src/lib/Vacancy.svelte
+++ b/src/lib/Vacancy.svelte
@@ -25,18 +25,18 @@
 
 <style> 
     article {
-            display: flex;
-            flex-wrap: wrap;
-            gap: 1.75em;
-            padding-bottom: 10%;
-            margin-bottom: 10%;
-            border-bottom: 1px solid black;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 1.75em;
+        padding-bottom: 10%;
+        margin-bottom: 10%;
+        border-bottom: 1px solid black;
     }
     .job-title {
-            width: 100%;
+        width: 100%;
     }
     .company, .language, .workweek, .city {
-            width: 40%;
+        width: 37.5%;
     }
 
     @media (min-width: 540px){

--- a/src/lib/Vacancy.svelte
+++ b/src/lib/Vacancy.svelte
@@ -5,8 +5,8 @@
 
 <article>
     <h4 class="job-title">{title}</h4>
-    <span class="language">{language}</span>
     <span class="company">{company}</span>
+    <span class="language">{language}</span>
     <span class="workweek">{hours}</span>
     <span class="city" >{city}</span>
 
@@ -23,51 +23,49 @@
 </article>
 
 
-<style>
-
-article {
-    display: grid;
-    grid-template-columns: 1fr 1fr; 
-    grid-template-rows: auto auto auto;
-    gap: 1.75em 0;
-    align-items: center;
-    margin-bottom: 15%;
-    padding-bottom: 15%;
-    border-bottom: 1px solid black;
-}
-
-article:last-child {
-    border-bottom: none;
-}
-
-@media (min-width: 620px){
+<style> 
     article {
-        grid-template-columns: repeat(3, 1fr);
-        margin-bottom: 7.5%;
-        padding-bottom: 7.5%;
-        
+            display: flex;
+            flex-wrap: wrap;
+            gap: 1.75em;
+            padding-bottom: 10%;
+            margin-bottom: 10%;
+            border-bottom: 1px solid black;
     }
-}
-
-@media (min-width: 820px){
-    article {
-        display: flex;
-        flex-direction: row;
-        justify-content: space-between;
-        margin-bottom: 4.5%;
-        padding-bottom: 4.5%;
+    .job-title {
+            width: 100%;
     }
-}
-
-@media (min-width: 1024px){
-    article {
-        display: flex;
-        flex-direction: row;
-        justify-content: space-between;
-        margin-bottom: 2.5%;
-        padding-bottom: 2.5%;
+    .company, .language, .workweek, .city {
+            width: 40%;
     }
-}
 
+    @media (min-width: 540px){
+        .company, .language, .workweek, .city {
+            width: 29%;
+        }
+    }
 
+    @media (min-width: 560px){
+        article {
+            padding-bottom: 5%;
+            margin-bottom: 5%;
+        }
+    }
+
+    @media (min-width: 812px){
+        article {
+            flex-direction: row;
+            flex-wrap: nowrap;
+            align-items: center;
+        }
+        .job-title {
+            width: 30%;
+        }
+        .company, .language{
+            width: 10%;
+        }
+        .workweek, .city {
+            width: 20%;
+        }
+    }
 </style>

--- a/src/routes/vacatures/+page.svelte
+++ b/src/routes/vacatures/+page.svelte
@@ -4,32 +4,32 @@
   let vacancies = [
     {
       title: "Digital Product Designer",
-      language: "ENG & NL",
       company: "Valsplat",
+      language: "ENG & NL",
       hours: "32-40",
       city: "NIEWUWERSLUIS",
       href: "href",
     },
     {
       title: "Traffic Manager",
-      language: "ENG & NL",
       company: "Triple",
+      language: "ENG & NL",
       hours: "32-40",
       city: "ALKMAAR",
       href: "href",
     },
     {
       title: "Astro Frontend Specialist",
-      language: "NL",
       company: "Valsplat",
+      language: "NL",
       hours: "32-40",
       city: "NIEUWERSLUIS",
       href: "href",
     },
     {
       title: "Design Lead",
-      language: "ENG & NL",
       company: "Fabrique",
+      language: "ENG & NL",
       hours: "32-40",
       city: "AMSTERDAM",
       href: "href",
@@ -47,8 +47,8 @@ subtitle="Verslim je carrière bij de beste digitale bureaus van Nederland. Pak 
   {#each vacancies as vacancy}
     <Vacancy
       title={vacancy.title}
-      language={vacancy.language}
       company={vacancy.company}
+      language={vacancy.language}
       hours={vacancy.hours}
       city={vacancy.city}
       href={vacancy.href}
@@ -67,6 +67,5 @@ subtitle="Verslim je carrière bij de beste digitale bureaus van Nederland. Pak 
       margin: 0 2.5% 0% 2.5%;
     }
   }
-
 
 </style>


### PR DESCRIPTION
# What does this change ❓

Met deze PR wil ik de remade/fixed vacature layout pushen, dit keer heb ik alleen flexbox gebruikt, wat het versimpeld heeft en uiteindelijk ook in minder lines v CSS. Ik merkte dat het voorheen onnodig ingewikkelde CSS was dus heb ik het even aangepast. 

# How has this been tested ? 

![image](https://github.com/user-attachments/assets/9f39f97d-b915-4a3f-a4c1-840fca6ee672)

![Screenshot 2024-10-15 at 22 09 15](https://github.com/user-attachments/assets/34c0611d-4a32-4c70-a622-0504958f2d1c)

![Screenshot 2024-10-15 at 22 09 27](https://github.com/user-attachments/assets/eed69c1c-fb1c-4b61-9775-e43259e35402)

# How to review ?

Dubbelchecken of er onnodige regels css in staan en eventueel of het werkt in een andere browser die ik nog niet getest heb
