### PR TITLE
Fix: added noscript styling to navigation

### DIFF
--- a/src/lib/display/Header.svelte
+++ b/src/lib/display/Header.svelte
@@ -42,4 +42,14 @@
       font-size: 1rem;
     }
   }
+
+  @media (scripting: none) {
+    header {
+      display: flex;
+      flex-direction: column;
+      height: fit-content;
+      max-height: 20rem;
+      overflow: auto;
+    }
+  }
 </style>

--- a/src/lib/display/Header.svelte
+++ b/src/lib/display/Header.svelte
@@ -1,4 +1,5 @@
 <script>
+  import { Header } from "$lib/display/Header.svelte";
   import Nav from "$lib/navigation/Nav.svelte";
   import Logo from "$lib/display/Logo.svelte";
 </script>
@@ -50,6 +51,12 @@
       height: fit-content;
       max-height: 20rem;
       overflow: auto;
+    }
+
+    @media (width >= 50rem) {
+      header {
+        min-height: 100vh;
+      }
     }
   }
 </style>

--- a/src/lib/input/ToggleButton.svelte
+++ b/src/lib/input/ToggleButton.svelte
@@ -1,71 +1,74 @@
 <script>
-    let { isOpen = false, toggle } = $props();
+  let { isOpen = false, toggle } = $props();
 </script>
-  
+
 <button onclick={toggle}>
-    {#if isOpen}
-        <span class="close">Close</span>
-    {:else}
-        <span class="menu">Menu</span>
-    {/if}
+  {#if isOpen}
+    <span class="close">Close</span>
+  {:else}
+    <span class="menu">Menu</span>
+  {/if}
 </button>
 
-  <style>
+<style>
+  button {
+    font-family: var(--martian-mono);
+    text-transform: uppercase;
+    font-size: 1.5rem;
+    background: none;
+    border: none;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 10;
+  }
+
+  span {
+    transition: 0.25s ease-in-out;
+  }
+
+  span.close {
+    animation: close 0.35s ease-in-out 0s;
+  }
+
+  @keyframes close {
+    from {
+      opacity: 0;
+      transform: translateX(-100px);
+    }
+    to {
+      opacity: 1;
+      transform: translateX(0);
+    }
+  }
+  span.menu {
+    animation: menu 0.35s ease-in-out 0s;
+    animation-fill-mode: both;
+  }
+
+  @keyframes menu {
+    from {
+      scale: 0.5;
+      opacity: 0;
+      transform: translateX(100px);
+    }
+    to {
+      scale: 1;
+      opacity: 1;
+      transform: translateX(0);
+    }
+  }
+
+  @media (width > 50rem) {
     button {
-      font-family: var(--martian-mono);
-      text-transform: uppercase;
-      font-size: 1.5rem;
-      background: none;
-      border: none;
-      cursor: pointer;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      z-index: 10;
+      display: none;
     }
-  
-    span {
-      transition: 0.25s ease-in-out;
+  }
+
+  @media (scripting: none) {
+    button {
+      display: none;
     }
-  
-    span.close {
-      animation: close 0.35s ease-in-out 0s;
-    }
-  
-    @keyframes close {
-      from {
-        opacity: 0;
-        transform: translateX(-100px);
-      }
-      to {
-        opacity: 1;
-        transform: translateX(0);
-      }
-    }
-    span.menu {
-      animation: menu 0.35s ease-in-out 0s;
-      animation-fill-mode: both;
-    }
-  
-  
-    @keyframes menu {
-      from {
-        scale: 0.5;
-        opacity: 0;
-        transform: translateX(100px);
-      }
-      to {
-        scale: 1;
-        opacity: 1;
-        transform: translateX(0);
-      }
-    }
-  
-  
-    @media (width > 50rem) {
-      button {
-        display: none;
-      }
-    }
-  
-  </style>
+  }
+</style>

--- a/src/lib/navigation/Nav.svelte
+++ b/src/lib/navigation/Nav.svelte
@@ -2,7 +2,6 @@
   import { onMount } from "svelte";
   import ToggleButton from "../input/ToggleButton.svelte";
   import NavItem from "./NavItem.svelte";
-  import { onMount } from "svelte";
 
   let isOpen = $state(false);
   let { openVacancies = 0 } = $props();
@@ -174,6 +173,30 @@
 
     div {
       display: none;
+    }
+  }
+
+  @media (scripting: none) {
+    nav {
+      position: relative;
+      display: block;
+      visibility: visible;
+      transform: translateX(0%);
+      opacity: 1;
+      height: fit-content;
+      width: fit-content;
+      border: none;
+    }
+
+    div {
+      display: none;
+    }
+
+    ul {
+      display: flex;
+      flex-direction: row;
+      overflow: scroll;
+      margin: 0;
     }
   }
 </style>

--- a/src/lib/navigation/Nav.svelte
+++ b/src/lib/navigation/Nav.svelte
@@ -198,5 +198,12 @@
       overflow: scroll;
       margin: 0;
     }
+
+    @media (width >= 50rem) {
+      ul {
+        flex-direction: column;
+        margin-top: 0;
+      }
+    }
   }
 </style>

--- a/static/global.css
+++ b/static/global.css
@@ -85,7 +85,7 @@ a:focus-visible,
 button:focus-visible {
   color: var(--blue);
   font-weight: bolder;
-  border: 3px dashed var(--blue);
+  outline: 3px dashed var(--blue);
 }
 
 .subtext {


### PR DESCRIPTION
# What does this change?

Resolves #225

With this PR I would like to add the code to give the navigation menu different styling when Javascript does not work.

## Demo

https://github.com/user-attachments/assets/6952a279-6485-446c-a51e-dcecf71b1f97

## Code

By using `@media (scripting: none)`, it's possible to give elements a different styling when JS is not available. I used it to make the nav visible again.

```css
@media (scripting: none) {
    nav {
      position: relative;
      display: block;
      visibility: visible;
      transform: translateX(0%);
      opacity: 1;
      height: fit-content;
      width: fit-content;
      border: none;
    }

    div {
      display: none;
    }

    ul {
      display: flex;
      flex-direction: row;
      overflow: scroll;
      margin: 0;
    }

    @media (width >= 50rem) {
      ul {
        flex-direction: column;
        margin-top: 0;
      }
    }
  }
```

For this I also had to change the header a little.

```css
@media (scripting: none) {
    header {
      display: flex;
      flex-direction: column;
      height: fit-content;
      max-height: 20rem;
      overflow: auto;
    }

    @media (width >= 50rem) {
      header {
        min-height: 100vh;
      }
    }
  }
```

# How to review?

You can test if it works as intended, wether the code is clear, readable, and up to our [conventions](https://github.com/fdnd-agency/voorhoede/issues/161).