### PR TITLE
Fix/intro section margin padding

### DIFF
--- a/src/lib/IntroSection.svelte
+++ b/src/lib/IntroSection.svelte
@@ -24,9 +24,13 @@
     justify-content: center;
     text-align: center;
     gap: 0.75em;
+    padding: 2rem;
+
     margin: 7.5% 0 15% 0;
   }
 
+  /*if spacing problem is not solved remove margin and change this to a min-width and max-width*/
+  /*and height for the spacing differents*/
   @media (min-width: 842px ){
       .intro-section {
         margin: 7.5% 20% 5% 20%;

--- a/src/lib/IntroSection.svelte
+++ b/src/lib/IntroSection.svelte
@@ -28,20 +28,6 @@
     margin: 3rem 0 3rem 0;
   }
 
-  @media (max-width: 842px ){
-    .intro-section {
-      min-height: 20rem;
-    }
-  }
-
-
-
-  @media (min-width: 842px ){
-      .intro-section {
-        margin: 7.5% 20% 5% 20%;
-      }
-  }
-
   @media (min-width: 1332px ){
       .intro-section {
         margin: 7.5% 25% 5% 25%;

--- a/src/lib/IntroSection.svelte
+++ b/src/lib/IntroSection.svelte
@@ -25,7 +25,13 @@
     text-align: center;
     gap: 0.75em;
     padding: 2rem;
-    /*margin: 7.5% 0 7.5% 0;*/
+    margin: 3rem 0 3rem 0;
+  }
+
+  @media (max-width: 842px ){
+    .intro-section {
+      min-height: 20rem;
+    }
   }
 
 

--- a/src/lib/IntroSection.svelte
+++ b/src/lib/IntroSection.svelte
@@ -25,12 +25,11 @@
     text-align: center;
     gap: 0.75em;
     padding: 2rem;
-
-    margin: 7.5% 0 15% 0;
+    /*margin: 7.5% 0 7.5% 0;*/
   }
 
-  /*if spacing problem is not solved remove margin and change this to a min-width and max-width*/
-  /*and height for the spacing differents*/
+
+
   @media (min-width: 842px ){
       .intro-section {
         margin: 7.5% 20% 5% 20%;

--- a/src/lib/display/Header.svelte
+++ b/src/lib/display/Header.svelte
@@ -16,6 +16,7 @@
     justify-content: space-between;
     overflow-x: hidden;
     overflow: hidden;
+    /*in the header the padding top is removed for the right padding and margin*/
     padding: 2rem 2rem 0rem 2rem;
     width: 100%;
     height: 100%;

--- a/src/lib/display/Header.svelte
+++ b/src/lib/display/Header.svelte
@@ -16,7 +16,7 @@
     justify-content: space-between;
     overflow-x: hidden;
     overflow: hidden;
-    padding: 2rem 2rem 2rem 2rem;
+    padding: 2rem 2rem 0rem 2rem;
     width: 100%;
     height: 100%;
   }

--- a/src/lib/display/Header.svelte
+++ b/src/lib/display/Header.svelte
@@ -16,7 +16,7 @@
     justify-content: space-between;
     overflow-x: hidden;
     overflow: hidden;
-    padding: 0.5rem 1rem;
+    padding: 2rem 2rem 2rem 2rem;
     width: 100%;
     height: 100%;
   }

--- a/static/global.css
+++ b/static/global.css
@@ -138,13 +138,6 @@ main {
   border-bottom: 1px solid var(--black);
 }
 
-/*@media (width <= 43rem) {*/
-/*  main{*/
-/*    padding: 0rem 2rem 2rem 2rem;*/
-/*  }*/
-
-/*}*/
-
 @media (width >= 43rem) {
   header,
   main,

--- a/static/global.css
+++ b/static/global.css
@@ -138,6 +138,12 @@ main {
   border-bottom: 1px solid var(--black);
 }
 
+/*@media (width <= 43rem) {*/
+/*  main{*/
+/*    padding: 0rem 2rem 2rem 2rem;*/
+/*  }*/
+
+/*}*/
 
 @media (width >= 43rem) {
   header,


### PR DESCRIPTION
<h1>What does this change</h1>

With this issue I have fix https://github.com/fdnd-agency/voorhoede/issues/218.

I change the padding and the margin on the `intro.section.svelte` and I used a media query for mobile.
I removed the padding-top on the `header.svelte`.



<h3>Before</h3>

![image](https://github.com/user-attachments/assets/5ff57246-7fa1-4793-a683-e473953b0e0b)

![image](https://github.com/user-attachments/assets/b2d084f8-a527-487b-afde-e0992c2942d8)

![image](https://github.com/user-attachments/assets/8b3ace9a-edfe-4851-a5bd-b5bdaa855a96)

<h3>After</h3>

The margin and padding on `introsection.svelte` are changed and I removed the padding-top on the `header.svelte`

![image](https://github.com/user-attachments/assets/3baa6ff6-5ced-42f4-98a4-f631943cacfd)


![image](https://github.com/user-attachments/assets/7db247c1-a4f1-4e32-9636-c8d2ab80154a)



<h2>Result</h2>

![image](https://github.com/user-attachments/assets/0e2ff6b7-6004-4749-9e09-4666ced46f1a)




<h1>How to review</h1>

You can test if the padding and margin on the class `intro-section` are equal on every page. 

You can also check if i used the correct [code conventions](https://github.com/fdnd-agency/voorhoede/issues/161).
